### PR TITLE
Cleanup listener events on dismount

### DIFF
--- a/src/components/Flow/Node/Node.Waveform.svelte
+++ b/src/components/Flow/Node/Node.Waveform.svelte
@@ -55,11 +55,13 @@
 		});
 		
 		// When song finishes in loop mode
-		$globalAudioPlayer?.addEventListener('ended', () => {
-			if (loopId && $currentAudioSource === audioUrl) {
+		const handleEnded = () => {
+			if (loopId && $currentAudioSource === audioUrl && $loops[loopId]?.isPlaying) {
 				advanceLoop(loops, loopId);
 			}
-		});
+		};
+		
+		$globalAudioPlayer?.addEventListener('ended', handleEnded);
 
 		// Sync waveform progress with global player
 		const updateTimer = setInterval(() => {
@@ -81,6 +83,8 @@
 				}
 				wavesurfer.destroy();
 			}
+			// Remove the ended event listener
+			$globalAudioPlayer?.removeEventListener('ended', handleEnded);
 		};
 	});
 

--- a/src/utils/audio.js
+++ b/src/utils/audio.js
@@ -8,7 +8,7 @@ import { get } from "svelte/store";
 // Debounce map to track timeouts for each audio URL
 let playTimeouts = {};
 
-export function handlePlay(audioUrl, id, reset = false) {
+export function handlePlay(audioUrl, id, reset = true) {
 	// Clear any existing timeout for this audio URL
 	if (playTimeouts[audioUrl]) {
 		clearTimeout(playTimeouts[audioUrl]);


### PR DESCRIPTION
Closes #103 

The "end" listener event is added to the global audio store on mount, but was not properly being cleaned up when destroyed. This resulted in multiple increments. Not entirely sure why/how this connects to the audio not advancing at all, but the improved version appears to resolve both issues.